### PR TITLE
Python v3.8 compatability

### DIFF
--- a/src/pupil_labs/real_time_screen_gaze/marker_generator.py
+++ b/src/pupil_labs/real_time_screen_gaze/marker_generator.py
@@ -3,7 +3,10 @@ import cv2
 apriltag_dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_APRILTAG_36h11)
 
 def generate_marker(marker_id, side_pixels=8, flip_x=False, flip_y=False):
-	image_data = apriltag_dict.generateImageMarker(marker_id, side_pixels, 0)
+	try:
+		image_data = apriltag_dict.generateImageMarker(marker_id, side_pixels, 0)
+	except:
+		image_data = apriltag_dict.drawMarker(marker_id, side_pixels)
 
 	flip_code = None
 	if flip_x and not flip_y:


### PR DESCRIPTION
On Python v3.8, you need to install opencv-python==4.5.1.48, where the function is called "drawMarker" instead of "generateImageMarker"